### PR TITLE
Move SAFE_STUP to motor status

### DIFF
--- a/motorApp/Db/motorStatus.db
+++ b/motorApp/Db/motorStatus.db
@@ -93,3 +93,21 @@ record(calc, "$(P)$(M):USING_ENCODER") {
     # Bitwise AND on MSTA to select the "encoder present" flag.
     field(CALC, "((A&256)=256)&&B")
 }
+
+record(bo, "$(P)$(M):SAFE_STUP") {
+  field(FLNK, "$(P)$(M):_SAFE_STUP.PROC")
+}
+
+record(calcout, "$(P)$(M):_SAFE_STUP") {
+  field(DTYP, "Soft Channel")
+  field(DESC, "Force Poll of motor position")
+  field(INPA, "$(P)$(M).MOVN")
+  field(INPB, "$(P)$(M).DMOV")
+  field(INPC, "$(P)$(M).HOMF")
+  field(INPD, "$(P)$(M).HOMR")
+  field(INPE, "$(P)$(M).JOGF")
+  field(INPF, "$(P)$(M).JOGR")
+  field(CALC, "(A=0)&&(B=1)&&(C=0)&&(D=0)&&(E=0)&&(F=0)")
+  field(OOPT, "When Non-zero")
+  field(OUT, "$(P)$(M).STUP PP")
+}

--- a/motorApp/Db/periodic_polling.db
+++ b/motorApp/Db/periodic_polling.db
@@ -1,25 +1,6 @@
-record(bo, "$(P)$(M):SAFE_STUP") {
-  field(FLNK, "$(P)$(M):_SAFE_STUP.PROC")
-}
-
-record(calcout, "$(P)$(M):_SAFE_STUP") {
-  field(DTYP, "Soft Channel")
-  field(DESC, "Force Poll of motor position")
-  field(INPA, "$(P)$(M).MOVN")
-  field(INPB, "$(P)$(M).DMOV")
-  field(INPC, "$(P)$(M).HOMF")
-  field(INPD, "$(P)$(M).HOMR")
-  field(INPE, "$(P)$(M).JOGF")
-  field(INPF, "$(P)$(M).JOGR")
-  field(CALC, "(A=0)&&(B=1)&&(C=0)&&(D=0)&&(E=0)&&(F=0)")
-  field(OOPT, "When Non-zero")
-  field(OUT, "$(P)$(M).STUP PP")
-}
-
 record(ao, "$(P)$(M):SCAN") {
   field(DTYP, "Soft Channel")
   field(DESC, "Every POLL_RATE calls SAFE_STUP")
   field(SCAN, "$(POLL_RATE=10) second")
   field(FLNK, "$(P)$(M):SAFE_STUP.PROC")
 }
-


### PR DESCRIPTION
Move these records (except periodic scan) to file loaded by all motor iocs so there is not a purple disconnected box on ibex advanced motor screen bottom right. This button is present for mclennans and a few others that poll via the motor record, but ones tat didn't need this would get a disconnecet button 

To check:
- confirm all iocs that load periodic_polling.db also load motorStatus.db (e.g. git grep in ioc/master)
- if run up ioc in simulation mode, motor advanced screen for a simulated motor that doesn't load periodic_polling should not have a purple box anymore i.e. no longer see this
 
<img width="437" height="299" alt="image" src="https://github.com/user-attachments/assets/341e7c47-56df-4b2b-af08-ba88eb7d2c8e" />
